### PR TITLE
fix: correct padding and margin values in navigation styles

### DIFF
--- a/app/components/Navigation/navigation.module.css
+++ b/app/components/Navigation/navigation.module.css
@@ -11,7 +11,7 @@
   flex-direction: row;
   justify-content: space-between;
   max-width: 1290px;
-  padding: 20 0 15;
+  padding: 20px 0px 15px;
 }
 
 .hamburgerMenu {
@@ -27,7 +27,7 @@
 
 .navLi {
   width: 100%;
-  margin: 0 25;
+  margin: 0px 25px;
 }
 
 .navA {
@@ -48,11 +48,11 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin: 0 0;
+    margin: 0px 0px;
   }
 
   .changeColors {
-    margin: 0 0;
+    margin: 0px 0px;
   }
 
   .navUl {
@@ -69,7 +69,7 @@
 
   .navLi {
     width: max-content;
-    margin-top: 20;
+    margin-top: 20px;
   }
   .navLi:last-child {
     padding-bottom: 30px;


### PR DESCRIPTION
# Description

**What is the context?** (Why these changes are required?)
The Navigation component's CSS had numeric padding/margin values without units (e.g. `padding: 20 0 15`, `margin: 0 25`), which are invalid CSS and get ignored by browsers. This fixes those values by adding the missing `px` units so the intended spacing actually applies.

**How has it been tested?**
Verified visually in the browser that the navigation bar padding/margins render as expected on desktop and mobile breakpoints.

**How to test it?**
Check the navigation bar spacing (padding around the nav container, margin around nav list items) on both desktop and mobile viewport widths, and confirm the hamburger menu items have proper spacing.

